### PR TITLE
[sc-330786][calendar-office365] Adds supported Python versions 3.12, 3.13, 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.1.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.12, 3.13, 3.14
+
 ## [Version 0.0.2](https://github.com/dataiku/dss-plugin-calendar-office365/releases/tag/v0.0.2) - Bugfix release - 2025-06
 
 - Updated code-env descriptor for DSS 12

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,12 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON39", "PYTHON310", "PYTHON311"],
+  "acceptedPythonInterpreters": [
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
   "corePackagesSet": "AUTO",
   "forceConda": false,
   "installCorePackages": true,

--- a/plugin.json
+++ b/plugin.json
@@ -1,13 +1,15 @@
 {
-    "id": "calendar-office365",
-    "version": "0.0.2",
-    "meta": {
-        "label": "Calendar office365",
-        "description": "Retrieve data from your Microsoft Office Calendar account.",
-        "author": "Dataiku (Vincent Breton)",
-        "icon": "icon-calendar",
-        "tags": ["Microsoft"],
-        "url": "https://www.dataiku.com/product/plugins/calendar-office365/",
-        "licenseInfo": "Apache Software License"
-    }
+  "id": "calendar-office365",
+  "version": "0.1.0",
+  "meta": {
+    "label": "Calendar office365",
+    "description": "Retrieve data from your Microsoft Office Calendar account.",
+    "author": "Dataiku (Vincent Breton)",
+    "icon": "icon-calendar",
+    "tags": [
+      "Microsoft"
+    ],
+    "url": "https://www.dataiku.com/product/plugins/calendar-office365/",
+    "licenseInfo": "Apache Software License"
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: ``
- Added supported Python versions: `3.12, 3.13, 3.14`
- Bumped plugin version: `0.1.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅